### PR TITLE
Updated to support Automapper 4.2 instance-based API

### DIFF
--- a/AutoMapper.Attributes.Tests.TestAssembly/AutoMapper.Attributes.Tests.TestAssembly.csproj
+++ b/AutoMapper.Attributes.Tests.TestAssembly/AutoMapper.Attributes.Tests.TestAssembly.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/AutoMapper.Attributes.Tests.TestAssembly/packages.config
+++ b/AutoMapper.Attributes.Tests.TestAssembly/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.1.1" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
 </packages>

--- a/AutoMapper.Attributes.Tests/AutoMapper.Attributes.Tests.csproj
+++ b/AutoMapper.Attributes.Tests/AutoMapper.Attributes.Tests.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
@@ -60,6 +60,7 @@
     <Compile Include="MapTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SubclassTests.cs" />
+    <Compile Include="TestMapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/AutoMapper.Attributes.Tests/MapsFromPropertyTests.cs
+++ b/AutoMapper.Attributes.Tests/MapsFromPropertyTests.cs
@@ -21,7 +21,7 @@ namespace AutoMapper.Attributes.Tests
                 }
             };
 
-            var container = Mapper.Map<Container>(deep);
+            var container = TestMapper.Mapper.Map<Container>(deep);
             Assert.That(container.OtherDeeperContainerName, Is.EqualTo(Grandma));
         }
 
@@ -30,7 +30,7 @@ namespace AutoMapper.Attributes.Tests
         {
             var deep = new DeepContainer();
 
-            var container = Mapper.Map<Container>(deep);
+            var container = TestMapper.Mapper.Map<Container>(deep);
             Assert.That(container.DeeperContainersName, Is.Null);
         }
     }

--- a/AutoMapper.Attributes.Tests/MapsFromTests.cs
+++ b/AutoMapper.Attributes.Tests/MapsFromTests.cs
@@ -8,7 +8,7 @@ namespace AutoMapper.Attributes.Tests
         [Test]
         public void MapperMapsNameProperty()
         {
-            var destination = Mapper.Map<DestinationData>(new SourceData
+            var destination = TestMapper.Mapper.Map<DestinationData>(new SourceData
             {
                 Name = Grandma
             });
@@ -18,7 +18,7 @@ namespace AutoMapper.Attributes.Tests
         [Test]
         public void MapperMapsUsingGenericConfigureMethod()
         {
-            var destination = Mapper.Map<DestinationData>(new SourceDataSpecialAttribute
+            var destination = TestMapper.Mapper.Map<DestinationData>(new SourceDataSpecialAttribute
             {
                 AnotherName = Grandma
             });
@@ -28,7 +28,7 @@ namespace AutoMapper.Attributes.Tests
         [Test]
         public void MapperMapsUsingNormalConfigureMethod()
         {
-            var destination = Mapper.Map<DestinationData>(new SourceDataNormalAttribute
+            var destination = TestMapper.Mapper.Map<DestinationData>(new SourceDataNormalAttribute
             {
                 YetAnotherName = Grandma
             });

--- a/AutoMapper.Attributes.Tests/MapsToPropertyTests.cs
+++ b/AutoMapper.Attributes.Tests/MapsToPropertyTests.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.Attributes.Tests
                 }
             };
 
-            var container = Mapper.Map<Container>(deep.DeeperContainer);
+            var container = TestMapper.Mapper.Map<Container>(deep.DeeperContainer);
             Assert.That(container.DeeperContainersName, Is.EqualTo(Grandma));
         }
 
@@ -25,7 +25,7 @@ namespace AutoMapper.Attributes.Tests
         {
             var deep = new DeeperContainer();
 
-            var container = Mapper.Map<Container>(deep);
+            var container = TestMapper.Mapper.Map<Container>(deep);
             Assert.That(container.DeeperContainersName, Is.Null);
         }
     }

--- a/AutoMapper.Attributes.Tests/MapsToTests.cs
+++ b/AutoMapper.Attributes.Tests/MapsToTests.cs
@@ -24,21 +24,21 @@ namespace AutoMapper.Attributes.Tests
         [Test]
         public void MapperMapsNameProperty()
         {
-            var destination = Mapper.Map<DestinationData>(SourceData);
+            var destination = TestMapper.Mapper.Map<DestinationData>(SourceData);
             Assert.That(destination.Name, Is.EqualTo(Grandma));
         }
 
         [Test]
         public void MapperMapsUsingGenericConfigureMethod()
         {
-            var destination = Mapper.Map<DestinationDataSpecialAttribute>(SourceData);
+            var destination = TestMapper.Mapper.Map<DestinationDataSpecialAttribute>(SourceData);
             Assert.That(destination.AnotherName, Is.EqualTo(Grandma));
         }
 
         [Test]
         public void MapperMapsUsingNormalConfigureMethod()
         {
-            var destination = Mapper.Map<DestinationDataNormalAttribute>(SourceData);
+            var destination = TestMapper.Mapper.Map<DestinationDataNormalAttribute>(SourceData);
             Assert.That(destination.YetAnotherName, Is.EqualTo(Grandma));
         }
     }

--- a/AutoMapper.Attributes.Tests/SubclassTests.cs
+++ b/AutoMapper.Attributes.Tests/SubclassTests.cs
@@ -14,7 +14,7 @@ namespace AutoMapper.Attributes.Tests
         public void SocialSecurityNumberIsMappedFromMapsFromPropertyAttribute()
         {
             var sourceEmployee = new SourceEmployee { SocialSecurityNumber = Grandma };
-            var targetEmployee = Mapper.Map<TargetEmployee>(sourceEmployee);
+            var targetEmployee = TestMapper.Mapper.Map<TargetEmployee>(sourceEmployee);
             Assert.That(targetEmployee.Ssn, Is.EqualTo(Grandma));
         }
 
@@ -22,7 +22,7 @@ namespace AutoMapper.Attributes.Tests
         public void EmployeeCodeIsMappedFromMapsToPropertyAttribute()
         {
             var sourceEmployee = new SourceEmployee { EmployeeId = Grandma };
-            var targetEmployee = Mapper.Map<TargetEmployee>(sourceEmployee);
+            var targetEmployee = TestMapper.Mapper.Map<TargetEmployee>(sourceEmployee);
             Assert.That(targetEmployee.Code, Is.EqualTo(Grandma));
         }
     }

--- a/AutoMapper.Attributes.Tests/TestMapper.cs
+++ b/AutoMapper.Attributes.Tests/TestMapper.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper.Attributes.Tests.TestAssembly.SubclassTests;
+
+namespace AutoMapper.Attributes.Tests
+{
+    public static class TestMapper
+    {
+        public static MapperConfiguration MapperConfiguration { get; set; }
+        public static IMapper Mapper  { get; set; }
+
+        static TestMapper()
+        {
+            MapperConfiguration = new MapperConfiguration(cfg => {
+                typeof(Person).Assembly.MapTypes(cfg);
+            });
+
+            Mapper = MapperConfiguration.CreateMapper();
+        }
+    }
+}

--- a/AutoMapper.Attributes.Tests/packages.config
+++ b/AutoMapper.Attributes.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.1.1" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />

--- a/AutoMapper.Attributes/AutoMapper.Attributes.csproj
+++ b/AutoMapper.Attributes/AutoMapper.Attributes.csproj
@@ -36,8 +36,8 @@
     <DocumentationFile>bin\Release\AutoMapper.Attributes.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.1.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/AutoMapper.Attributes/packages.config
+++ b/AutoMapper.Attributes/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.1.1" targetFramework="net45" />
+  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Automapper 4.2 marked the static API as obsolete.  I added an optional parameter to MapTypes to allow passing in a MappingConfiguration.

I also converted the unit tests to use the instance based API.