### PR TITLE
Update Extensions.cs

### DIFF
--- a/AutoMapper.Attributes.V5/Extensions.cs
+++ b/AutoMapper.Attributes.V5/Extensions.cs
@@ -21,8 +21,8 @@ namespace AutoMapper.Attributes
                 assemblyTypes.Select(t => new
                 {
                     Type = t,
-                    MapsToAttributes = t.GetCustomAttributes(typeof(MapsToAttribute), true).Cast<MapsToAttribute>(),
-                    MapsFromAttributes = t.GetCustomAttributes(typeof(MapsFromAttribute), true).Cast<MapsFromAttribute>(),
+                    MapsToAttributes = t.GetCustomAttributes(typeof(MapsToAttribute), false).Cast<MapsToAttribute>(),
+                    MapsFromAttributes = t.GetCustomAttributes(typeof(MapsFromAttribute), false).Cast<MapsFromAttribute>(),
                 })
                 .Where(t => t.MapsToAttributes.Any() || t.MapsFromAttributes.Any());
             


### PR DESCRIPTION
Fixes the https://github.com/schneidenbach/AutoMapper.Attributes/issues/23
Also forces a user to explicitly set the attribute on their DTOs. There is no point in hoping for an inheritance since the derived class needs its own `CreateMap` call.